### PR TITLE
Simplify api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: go
 
-sudo: required
-language: go
-
 go:
 - "1.11.x"
 
@@ -11,4 +8,4 @@ install:
   - go get github.com/golang/mock/gomock
   - go install github.com/golang/mock/mockgen
 
-script: make generate test
+script: make

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ dependencies:
 	GO111MODULE=on go mod download
 
 test:
-	GO111MODULE=on go test ./... --cover -tags=$(TEST_TAGS)
+	GO111MODULE=on go test ./... --cover -v -tags=$(TEST_TAGS)
 
 generate:
 	GO111MODULE=on go generate ./...

--- a/middleware.go
+++ b/middleware.go
@@ -11,6 +11,7 @@ import (
 //go:generate mockgen -destination ./mocks/http_handler.go -mock_names Handler=MockHTTPHandler -package mocks net/http Handler
 
 //go:generate mockgen -destination ./mocks/middleware_handler.go -package mocks github.com/darren-west/middleware Handler
+
 type (
 	Runner struct {
 		options *Options
@@ -112,6 +113,10 @@ func UseHandler(h http.Handler) Option {
 		o.Handler = h
 		return
 	}
+}
+
+func UseHandlerFunc(h http.HandlerFunc) Option {
+	return UseHandler(h)
 }
 
 func (hs HandlerIterator) ForEach(f func(Handler)) {

--- a/middleware.go
+++ b/middleware.go
@@ -39,16 +39,15 @@ func (h *Runner) Options() Options {
 }
 
 func (h *Runner) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	next := h.options.Handler
+	last := h.options.Handler
 	for i := h.options.Middleware.Count() - 1; i >= 0; i-- {
-		mid := h.options.Middleware[i]
-		next = func(n http.Handler) http.HandlerFunc {
+		last = func(mid Handler, next http.Handler) http.HandlerFunc {
 			return func(w http.ResponseWriter, r *http.Request) {
-				mid.ServeHTTP(w, r, n.ServeHTTP)
+				mid.ServeHTTP(w, r, next.ServeHTTP)
 			}
-		}(next)
+		}(h.options.Middleware[i], last)
 	}
-	next.ServeHTTP(w, r)
+	last.ServeHTTP(w, r)
 }
 
 func New(setters ...Option) (*Runner, error) {

--- a/middleware.go
+++ b/middleware.go
@@ -68,7 +68,7 @@ func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request, next Next
 func newOptions(optsetters ...Option) (*Options, error) {
 	opts := &Options{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			fmt.Fprintf(w, "Hello World!")
+			fmt.Fprintf(w, "hello world!")
 		}),
 		Middleware: []Handler{},
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -91,8 +91,8 @@ func TestHandlerMiddleware_Invoked(t *testing.T) {
 	mockMiddleware.EXPECT().ServeHTTP(rec, req, gomock.Any()).
 		Return().
 		Times(1).
-		Do(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
-			next.ServeHTTP(w, r)
+		Do(func(w http.ResponseWriter, r *http.Request, next middleware.Next) {
+			next(w, r)
 		})
 	handler.ServeHTTP(rec, req)
 }
@@ -123,24 +123,24 @@ func TestHandlerMiddleware_MultipleMiddleware(t *testing.T) {
 	mockHandler := mocks.NewMockHTTPHandler(cont)
 	handler, err := middleware.New(
 		middleware.WithFunc(
-			func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+			func(w http.ResponseWriter, r *http.Request, next middleware.Next) {
 				fmt.Fprintf(w, "1")
-				next.ServeHTTP(w, r)
+				next(w, r)
 			},
-			func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+			func(w http.ResponseWriter, r *http.Request, next middleware.Next) {
 				assert.Equal(t, "1", w.(*httptest.ResponseRecorder).Body.String())
 				fmt.Fprintf(w, "2")
-				next.ServeHTTP(w, r)
+				next(w, r)
 			},
-			func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+			func(w http.ResponseWriter, r *http.Request, next middleware.Next) {
 				assert.Equal(t, "12", w.(*httptest.ResponseRecorder).Body.String())
 				fmt.Fprintf(w, "3")
-				next.ServeHTTP(w, r)
+				next(w, r)
 			},
-			func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+			func(w http.ResponseWriter, r *http.Request, next middleware.Next) {
 				assert.Equal(t, "123", w.(*httptest.ResponseRecorder).Body.String())
 				fmt.Fprintf(w, "4")
-				next.ServeHTTP(w, r)
+				next(w, r)
 			},
 		),
 		middleware.UseHandler(mockHandler),

--- a/mocks/middleware_handler.go
+++ b/mocks/middleware_handler.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	middleware "github.com/darren-west/middleware"
 	gomock "github.com/golang/mock/gomock"
 	http "net/http"
 	reflect "reflect"
@@ -34,7 +35,7 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // ServeHTTP mocks base method
-func (m *MockHandler) ServeHTTP(arg0 http.ResponseWriter, arg1 *http.Request, arg2 http.Handler) {
+func (m *MockHandler) ServeHTTP(arg0 http.ResponseWriter, arg1 *http.Request, arg2 middleware.Next) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ServeHTTP", arg0, arg1, arg2)
 }


### PR DESCRIPTION
A few changes to simplify the api and improve testing.
Handler now uses next function rather than http.Handler as it is cleaner than calling ServeHTTP